### PR TITLE
 ci: Use fcos buildroot 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    container: quay.io/cgwalters/fcos-buildroot
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
 So we have the latest libostree.